### PR TITLE
ENT_QUOTES Prevents text escaping error

### DIFF
--- a/lib/AsanaHipchat.php
+++ b/lib/AsanaHipchat.php
@@ -504,7 +504,7 @@ class AsanaHipchat
 			$taskdata = $singletaskJson->data;
 
 			$creator = htmlentities($taskdata->followers[0]->name, ENT_COMPAT, "UTF-8");
-			$name = htmlentities($taskdata->name, ENT_COMPAT, "UTF-8");
+			$name = htmlentities($taskdata->name, ENT_QUOTES, "UTF-8");
 
 			$assignee = 'not set';
 			if (!empty($taskdata->assignee))


### PR DESCRIPTION
ENT_COMPAT only escapes double-quotes. ENT_QUOTES will escape both single and double quotes, addressing the error that sends multiple messages to Hipchat when a user enters a task name that includes '.
